### PR TITLE
Uses configuration file for input/output dirs

### DIFF
--- a/java/parser/src/main/java/de/fhdw/deviceanalyzer/DeviceAnalyzerClient.java
+++ b/java/parser/src/main/java/de/fhdw/deviceanalyzer/DeviceAnalyzerClient.java
@@ -1,7 +1,10 @@
 package de.fhdw.deviceanalyzer;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Properties;
 
 public class DeviceAnalyzerClient {
 
@@ -10,7 +13,7 @@ public class DeviceAnalyzerClient {
 	public static void main(String[] args) throws IOException {
 		Locale.setDefault(Locale.UK);
 
-		final IModule module = (args.length == 1) ? selectModule(args[0].toLowerCase()) : null;
+		final IModule module = selectModule(args);
 
 		final Thread mainThread = Thread.currentThread();
 		Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -27,14 +30,23 @@ public class DeviceAnalyzerClient {
 		if (module != null) {
 			module.execute();
 		} else {
-			System.err.println("usage: [parse]");
+			System.err.println("usage: parse config-file-path");
 		}
 	}
 
-	private static IModule selectModule(String command) {
+	private static IModule selectModule(String [] args) throws FileNotFoundException, IOException {
+		String command = args[0].toLowerCase();
 		switch (command) {
 		case CMD_PARSE:
-			return new ParsingModule();
+			if (args.length !=  2)
+				return null;
+
+			// Reads the properties file
+			String configPath = args[1];
+			Properties properties = new Properties();
+			properties.load(new FileInputStream(configPath));
+			return new ParsingModule(properties);
+
 		default:
 			return null;
 		}

--- a/java/parser/src/main/java/de/fhdw/deviceanalyzer/ParsingModule.java
+++ b/java/parser/src/main/java/de/fhdw/deviceanalyzer/ParsingModule.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import de.fhdw.deviceanalyzer.parser.CellBasedContextLocationParser;
@@ -29,12 +30,22 @@ import de.fhdw.deviceanalyzer.parser.core.Event;
 
 public class ParsingModule implements IModule {
 
-	public static final Path DIR_DOWNLOAD = Paths.get("~/device-analyzer/dataset");
-	public static final Path DIR_LOCKED = Paths.get("~/results/locked_sessions");
-	public static final Path DIR_WIRELESS = Paths.get("~/results/wireless");
-	public static final Path DIR_UNLOCKED = Paths.get("~/results/unlocked_sessions");
-	public static final Path DIR_DEVICES = Paths.get("~/results/devices");
-	public static final Path DIR_DONE = Paths.get("~/results/done");
+	// Property keys
+	public static final String DIR_DOWNLOAD_KEY = "DIR_DOWNLOAD";
+	public static final String DIR_LOCKED_KEY = "DIR_LOCKED";
+	public static final String DIR_WIRELESS_KEY = "DIR_WIRELESS";
+	public static final String DIR_UNLOCKED_KEY = "DIR_UNLOCKED";
+	public static final String DIR_DEVICES_KEY = "DIR_DEVICES";
+	public static final String DIR_DONE_KEY = "DIR_DONE";
+
+	private final Path DIR_DOWNLOAD;
+	private final Path DIR_LOCKED;
+	private final Path DIR_WIRELESS;
+	private final Path DIR_UNLOCKED;
+	private final Path DIR_DEVICES;
+	private final Path DIR_DONE;
+
+	private Properties properties;
 
 	private volatile boolean shutdown = false;
 
@@ -42,7 +53,16 @@ public class ParsingModule implements IModule {
 
 	private AtomicInteger counter = new AtomicInteger();
 
-	public ParsingModule() {
+	public ParsingModule(Properties properties) {
+		this.properties = properties;
+
+		DIR_DOWNLOAD = Paths.get(properties.getProperty(DIR_DOWNLOAD_KEY));
+		DIR_LOCKED = Paths.get(properties.getProperty(DIR_LOCKED_KEY));
+		DIR_WIRELESS = Paths.get(properties.getProperty(DIR_WIRELESS_KEY));
+		DIR_UNLOCKED = Paths.get(properties.getProperty(DIR_UNLOCKED_KEY));
+		DIR_DEVICES = Paths.get(properties.getProperty(DIR_DEVICES_KEY));
+		DIR_DONE = Paths.get(properties.getProperty(DIR_DONE_KEY));
+
 		DIR_LOCKED.toFile().mkdirs();
 		DIR_UNLOCKED.toFile().mkdirs();
 		// DIR_WIRELESS.toFile().mkdirs();
@@ -106,7 +126,7 @@ public class ParsingModule implements IModule {
 		mainParser.add(wifiScanContextParser);
 		mainParser.add(deviceInfoParser);
 		// mainParser.add(wirelessInfoParser);
-		mainParser.add(new SessionParser(deviceInfoParser, sessionFoulDateParser));
+		mainParser.add(new SessionParser(deviceInfoParser, sessionFoulDateParser, properties));
 
 		parse(file, vanguardParser);
 		parse(file, mainParser);

--- a/java/parser/src/main/java/de/fhdw/deviceanalyzer/parser/SessionParser.java
+++ b/java/parser/src/main/java/de/fhdw/deviceanalyzer/parser/SessionParser.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.base.Objects;
@@ -71,9 +72,12 @@ public class SessionParser implements IParser {
 
 	private DeviceInfo deviceInfo;
 
-	public SessionParser(DeviceInfoParser deviceInfoParser, SessionFoulDateParser sessionFoulDateParser) {
+	private Properties properties;
+
+	public SessionParser(DeviceInfoParser deviceInfoParser, SessionFoulDateParser sessionFoulDateParser, Properties properties) {
 		this.deviceInfoParser = deviceInfoParser;
 		this.sessionFoulDateParser = sessionFoulDateParser;
+		this.properties = properties;
 	}
 
 	@Override
@@ -221,9 +225,9 @@ public class SessionParser implements IParser {
 		lockedSessionLine.add(0, Session.getFileHeading(false));
 		unlockedSessionLine.add(0, Session.getFileHeading(true));
 
-		FileUtil.writeToFile(lockedSessionLine, new File(ParsingModule.DIR_LOCKED.toFile(), deviceId + ".csv"));
-		FileUtil.writeToFile(unlockedSessionLine, new File(ParsingModule.DIR_UNLOCKED.toFile(), deviceId + ".csv"));
-		deviceInfo.writeToFile(new File(ParsingModule.DIR_DEVICES.toFile(), "devices.csv"));
+		FileUtil.writeToFile(lockedSessionLine, new File(properties.getProperty(ParsingModule.DIR_LOCKED_KEY), deviceId + ".csv"));
+		FileUtil.writeToFile(unlockedSessionLine, new File(properties.getProperty(ParsingModule.DIR_UNLOCKED_KEY), deviceId + ".csv"));
+		deviceInfo.writeToFile(new File(properties.getProperty(ParsingModule.DIR_DEVICES_KEY), "devices.csv"));
 	}
 
 	private void parseEventForSession(Event event) {

--- a/java/parser/src/main/java/de/fhdw/deviceanalyzer/parser/WirelessInfoParser.java
+++ b/java/parser/src/main/java/de/fhdw/deviceanalyzer/parser/WirelessInfoParser.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import de.fhdw.deviceanalyzer.ParsingModule;
@@ -21,8 +22,11 @@ public class WirelessInfoParser implements IParser {
 	private WirelessLogEntry currentBluetoothLog;
 	private Set<String> currentMACs = new HashSet<>();
 
-	public WirelessInfoParser(DeviceInfoParser deviceInfoParser) {
+	private Properties properties;
+
+	public WirelessInfoParser(DeviceInfoParser deviceInfoParser, Properties properties) {
 		this.deviceInfoParser = deviceInfoParser;
+		this.properties = properties;
 	}
 
 	@Override
@@ -76,7 +80,7 @@ public class WirelessInfoParser implements IParser {
 	public void endParsing(String deviceId) {
 		lines.add(0, WirelessLogEntry.getFileHeading());
 
-		FileUtil.writeToFile(lines, new File(ParsingModule.DIR_WIRELESS.toFile(), deviceId + ".csv"));
+		FileUtil.writeToFile(lines, new File(properties.getProperty(ParsingModule.DIR_WIRELESS_KEY), deviceId + ".csv"));
 	}
 
 }


### PR DESCRIPTION
This patch removes hard-coded file paths in the code. Instead, it uses a
configuration file passed as a command-line argument to determine input
and output dirs.

So, to run the program:

> java -jar parser.jar parse /path/to/config.properties

The config file must follow the format recognized by `java.util.Properties`.
It must contain the following keys:

* DIR_DOWNLOAD: path to dir containing data files (in csv)
* DIR_LOCKED: output dir to which locked sessions will be saved
* DIR_UNLOCKED: output dir to which unlocked sessions will be saved
* DIR_WIRELESS: output dir to which wireless info will be saved
* DIR_DEVICES: output dir to which device info will be saved
* DIR_DONE: output dir to which progress information will be saved.
After processing an input file, the program creates an output file with same
name (and adds a .done extension) in this dir. In subsequent running,
the program will skip all corresponding input files. If you want to
re-process an input file, delete its corresponding file from this dir.

Here is an example of a config file:

```
DIR_DOWNLOAD = /tmp/dataset/
DIR_LOCKED = /tmp/results/locked_sessions/
DIR_UNLOCKED = /tmp/results/unlocked_sessions/
DIR_WIRELESS = /tmp/results/wireless/
DIR_DEVICES = /tmp/results/devices/
DIR_DONE = /tmp/results/done/
```